### PR TITLE
Implement error handling for username input

### DIFF
--- a/app/src/main/java/com/example/cofee_shop/presentation/activities/UsernameActivity.kt
+++ b/app/src/main/java/com/example/cofee_shop/presentation/activities/UsernameActivity.kt
@@ -17,16 +17,17 @@ class UsernameActivity : AppCompatActivity() {
 
     private val btnContinue: Button by lazy { findViewById(R.id.btnContinue) }
     private val etUsername by lazy { findViewById<android.widget.EditText>(R.id.etUsername) }
-    private val enterUsernameViewModel: EnterUsernameViewModel by viewModels()
+    private val viewModel: EnterUsernameViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_username)
         lifecycleScope.launch {
-            enterUsernameViewModel.userName.collect { username ->
-                if (etUsername.text.toString() != username) {
-                    etUsername.setText(username)
+            viewModel.enterUserState.collect { usernameState ->
+                if (etUsername.text.toString() != usernameState.userName) {
+                    etUsername.setText(usernameState.userName)
                 }
+                etUsername.error = usernameState.errorMessage
             }
         }
         setupListeners()
@@ -34,15 +35,18 @@ class UsernameActivity : AppCompatActivity() {
 
     private fun setupListeners() {
         btnContinue.setOnClickListener {
-            if (etUsername.text.isNullOrBlank()) return@setOnClickListener
-            enterUsernameViewModel.saveUserName().invokeOnCompletion {
+            if (etUsername.text.isNullOrBlank()) {
+                viewModel.displayError("Username cannot be empty")
+                return@setOnClickListener
+            }
+            viewModel.saveUserName().invokeOnCompletion {
                 runOnUiThread { navigateToMain() }
             }
         }
         etUsername.addTextChangedListener(object : android.text.TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                enterUsernameViewModel.onUserNameChanged(s.toString())
+                viewModel.onUserNameChanged(s.toString())
             }
             override fun afterTextChanged(s: android.text.Editable?) {}
         })

--- a/app/src/main/java/com/example/cofee_shop/presentation/managers/EnterUsernameViewModel.kt
+++ b/app/src/main/java/com/example/cofee_shop/presentation/managers/EnterUsernameViewModel.kt
@@ -14,13 +14,18 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+data class UserNameState(
+    val userName: String = "",
+    val errorMessage: String? = null
+)
+
 @HiltViewModel
 class EnterUsernameViewModel @Inject constructor(
     private val saveUserNameUseCase: SaveUserNameUseCase
 ) : ViewModel() {
 
-    private val _userName = MutableStateFlow("")
-    val userName: StateFlow<String> get() = _userName.asStateFlow()
+    private val _enterUserState = MutableStateFlow(UserNameState())
+    val enterUserState: StateFlow<UserNameState> get() = _enterUserState.asStateFlow()
 
     fun saveUserName(): Job {
         val coroutineExceptionHandler = CoroutineExceptionHandler { _, exception ->
@@ -29,7 +34,7 @@ class EnterUsernameViewModel @Inject constructor(
 
         return viewModelScope.launch(coroutineExceptionHandler) {
             runCatching {
-                saveUserNameUseCase(userName.value)
+                saveUserNameUseCase(enterUserState.value.userName)
             }.onFailure {
                 Log.e("EnterUsernameViewModel", "Failed to save username", it)
             }
@@ -37,6 +42,14 @@ class EnterUsernameViewModel @Inject constructor(
     }
 
     fun onUserNameChanged(newName: String) {
-        _userName.update { newName }
+        _enterUserState.update {
+            it.copy(userName = newName, errorMessage = null)
+        }
+    }
+
+    fun displayError(message: String) {
+        _enterUserState.update {
+            it.copy(errorMessage = message)
+        }
     }
 }


### PR DESCRIPTION
This commit introduces error handling for the username input field in the `UsernameActivity`.

- A `UserNameState` data class is added to encapsulate the username string and any potential error message.
- `EnterUsernameViewModel` is updated to use `UserNameState` to manage the username and its validation state.
- `UsernameActivity` now observes `enterUserState` from the ViewModel to display error messages directly in the `EditText` field if the username is empty.
- A new method `displayError` is added to `EnterUsernameViewModel` to update the error message in `UserNameState`.
- The ViewModel variable in `UsernameActivity` is renamed from `enterUsernameViewModel` to `viewModel` for brevity.