### PR TITLE
feat: fix navigation issue 

### DIFF
--- a/app/src/main/java/com/example/cofee_shop/presentation/activities/MainActivity.kt
+++ b/app/src/main/java/com/example/cofee_shop/presentation/activities/MainActivity.kt
@@ -7,6 +7,7 @@ import android.graphics.drawable.shapes.RectShape
 import android.os.Bundle
 import android.util.Log
 import android.view.Gravity
+import android.view.View
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
@@ -49,14 +50,28 @@ class MainActivity : AppCompatActivity() {
 
     private fun setupCustomUnderline(navController: NavController) {
         navController.addOnDestinationChangedListener { _, destination, _ ->
-            val selectedIndex = when (destination.id) {
-                R.id.homeFragment -> 0
-                R.id.drinkMenuFragment -> 1
-                R.id.orderFragment -> 2
-                R.id.favoritesFragment -> 3
-                else -> 0
+            when (destination.id) {
+                R.id.coffeeDetailFragment -> {
+                    binding.bottomNav.visibility = View.GONE
+                }
+                R.id.homeFragment,
+                R.id.drinkMenuFragment,
+                R.id.orderFragment,
+                R.id.favoritesFragment -> {
+                    binding.bottomNav.visibility = View.VISIBLE
+                    val selectedIndex = when (destination.id) {
+                        R.id.homeFragment -> 0
+                        R.id.drinkMenuFragment -> 1
+                        R.id.orderFragment -> 2
+                        R.id.favoritesFragment -> 3
+                        else -> 0
+                    }
+                    addUnderlineToSelectedItem(selectedIndex)
+                }
+                else -> {
+                    binding.bottomNav.visibility = View.GONE
+                }
             }
-            addUnderlineToSelectedItem(selectedIndex)
         }
 
         addUnderlineToSelectedItem(0)


### PR DESCRIPTION
This pull request updates the visibility logic for the bottom navigation bar in the `MainActivity`. The navigation bar will now be hidden when navigating to certain fragments, such as the coffee detail screen, and shown only on main sections like home, drink menu, orders, and favorites.

Navigation bar visibility improvements:

* Updated `setupCustomUnderline` in `MainActivity` to hide the bottom navigation bar (`binding.bottomNav.visibility = View.GONE`) when navigating to `coffeeDetailFragment` and any other fragment not explicitly listed, and show it only on `homeFragment`, `drinkMenuFragment`, `orderFragment`, and `favoritesFragment`. [[1]](diffhunk://#diff-71b69b2062f3a5e94cedd7fe511a7e05b71af65bbc5a6a5fb131e8aa9eba0561R53-R61) [[2]](diffhunk://#diff-71b69b2062f3a5e94cedd7fe511a7e05b71af65bbc5a6a5fb131e8aa9eba0561R71-R75)

Other changes:

* Added import for `android.view.View` in `MainActivity.kt` to support visibility changes.…methods to suspend functions